### PR TITLE
add method apply - allow call external methods

### DIFF
--- a/lib/chainable_methods.rb
+++ b/lib/chainable_methods.rb
@@ -13,6 +13,11 @@ module ChainableMethods
       @context = context
     end
 
+		def apply(&block)
+			@state = block.call @state
+			ChainableMethods::Link.new(@state, @context)
+		end
+
     def method_missing(name, *args, &block)
       if state.respond_to?(name)
         ChainableMethods::Link.new( state.send(name, *args, &block), context)

--- a/test/chainable_methods_test.rb
+++ b/test/chainable_methods_test.rb
@@ -77,4 +77,14 @@ class ChainableMethodsTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::ChainableMethods::VERSION
   end
+
+	def test_that_it_accepts_external_methods
+		initial_state = "a b c d e f"
+
+		result = FooModule.chain_from(initial_state).
+				apply {|x| x.upcase }.
+				unwrap
+
+		assert_equal result, "A B C D E F"
+	end
 end


### PR DESCRIPTION
It's possible in the actual implementation call methods/functions that exist outside `MyModule`?

> result = FooModule.chain_from(initial_state).
>               apply {|x| do_stuffs(x) }.
>               unwrap

where x.upcase can call any method passing x and returning a new `ChainableMethods`

by the way, I don't usually write ruby, so may have a better implementation,

Thanks!
